### PR TITLE
Add a randomforest option to create many dependent jobs.

### DIFF
--- a/chronos-jobs.py
+++ b/chronos-jobs.py
@@ -64,6 +64,7 @@ def main(args=None):
   elif args.createforest != None:
     p1 = 0.6
     p2 = 0.2
+    available_parents = 0
     static_payload = {
       "async": False,
       "command": "sleep 50",
@@ -78,16 +79,20 @@ def main(args=None):
     for i in range(args.createforest):
       payload = dict(static_payload) # Create a copy
       payload["name"] = "DEPENDENTJOB%i" % i
-      if random.random() < p2 and i > 2:
+      if random.random() < p2 and available_parents > 2:
         # With probability p2, this node will have two parents selected at random from the list of completed payloads.
         payload["parents"] = [obj['name'] for obj in random.sample(payloads, 2)]
+        available_parents += 1
         url = "/scheduler/dependency"
-      elif random.random() < p1 and i > 1:
+      elif random.random() < p1 and available_parents > 1:
         # With probability p1, this node will have a single parent selected at random from the list of completed payloads.
         payload["parents"] = [obj['name'] for obj in random.sample(payloads, 1)]
+        available_parents += 1
         url = "/scheduler/dependency"
       else:
         # This job is a root job with no parents, so it must be scheduled.
+        now = datetime.datetime.utcnow()
+        available_parents += 1
         payload["schedule"] = "R/%s/PT24H" % now.isoformat()
         url = "/scheduler/iso8601"
 

--- a/chronos-jobs.py
+++ b/chronos-jobs.py
@@ -78,16 +78,21 @@ def main(args=None):
     for i in range(args.createforest):
       payload = dict(static_payload) # Create a copy
       payload["name"] = "DEPENDENTJOB%i" % i
-      payload["parents"] = []
-      # With probability p2, this node will have two parents selected at random from the list of completed payloads.
       if random.random() < p2 and i > 2:
+        # With probability p2, this node will have two parents selected at random from the list of completed payloads.
         payload["parents"] = [obj['name'] for obj in random.sample(payloads, 2)]
-      # With probability p1, this node will have a single parent selected at random from the list of completed payloads.
+        url = "/scheduler/dependency"
       elif random.random() < p1 and i > 1:
+        # With probability p1, this node will have a single parent selected at random from the list of completed payloads.
         payload["parents"] = [obj['name'] for obj in random.sample(payloads, 1)]
+        url = "/scheduler/dependency"
+      else:
+        # This job is a root job with no parents, so it must be scheduled.
+        payload["schedule"] = "R/%s/PT24H" % now.isoformat()
+        url = "/scheduler/iso8601"
 
       payloads.append(payload)
-      connection.request("POST", "/scheduler/dependency", json.dumps(payload), headers)
+      connection.request("POST", url, json.dumps(payload), headers)
       connection.getresponse().read()
     connection.close()
     print "Created %i dependent job(s) on local Chronos" % args.createforest

--- a/chronos-jobs.py
+++ b/chronos-jobs.py
@@ -5,6 +5,7 @@ import datetime
 import httplib
 import json
 import sys
+import random
 
 from lib.texttable import texttable
 
@@ -20,6 +21,8 @@ def main(args=None):
   group = parser.add_mutually_exclusive_group(required=True)
   group.add_argument("--create", const=1, metavar="<n>", nargs="?", type=int,
                       help="create <n> sleep jobs (default: 1)")
+  group.add_argument("--createforest", const=1, metavar="<n>", nargs="?", type=int,
+                      help="create <n> sleep jobs, with random dependencies (default: 1)")
   group.add_argument("--delete", metavar="<jobname>",
                       help="delete job with name <jobname>")
   group.add_argument("--deleteall", action="store_true",
@@ -57,6 +60,38 @@ def main(args=None):
 
     connection.close()
     print "Created %i job(s) on local Chronos" % args.create
+
+  elif args.createforest != None:
+    p1 = 0.6
+    p2 = 0.2
+    static_payload = {
+      "async": False,
+      "command": "sleep 50",
+      "disabled": False,
+      "executor": "",
+      "epsilon": "PT15M",
+      "owner": "rob@fake.com"
+    }
+    headers = {"Content-type": "application/json"}
+    connection = httplib.HTTPConnection(args.hostname)
+    payloads = []
+    for i in range(args.createforest):
+      payload = dict(static_payload) # Create a copy
+      payload["name"] = "DEPENDENTJOB%i" % i
+      payload["parents"] = []
+      # With probability p2, this node will have two parents selected at random from the list of completed payloads.
+      if random.random() < p2 and i > 2:
+        payload["parents"] = [obj['name'] for obj in random.sample(payloads, 2)]
+      # With probability p1, this node will have a single parent selected at random from the list of completed payloads.
+      elif random.random() < p1 and i > 1:
+        payload["parents"] = [obj['name'] for obj in random.sample(payloads, 1)]
+
+      payloads.append(payload)
+      connection.request("POST", "/scheduler/dependency", json.dumps(payload), headers)
+      connection.getresponse().read()
+    connection.close()
+    print "Created %i dependent job(s) on local Chronos" % args.createforest
+
   elif args.delete != None:
     connection = httplib.HTTPConnection(args.hostname)
     connection.request("DELETE", "/scheduler/job/%s" % args.delete)


### PR DESCRIPTION
Also adds an **init**.py file to lib/texttable so it loads properly.

Here's some (printed) sample output:

Tue Jan 21 14:37:25 mrdmnd@anglerfish ~/airbnb/chronos-utils  (random-forests) $ ./chronos.py jobs --createforest 15
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB0', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': []}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB1', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': []}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB2', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB0']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB3', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': []}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB4', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB3', 'DEPENDENTJOB2']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB5', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB3']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB6', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': []}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB7', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB5']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB8', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB3', 'DEPENDENTJOB1']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB9', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB6']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB10', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB0']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB11', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': []}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB12', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': []}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB13', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB8']}
{'disabled': False, 'async': False, 'command': 'sleep 50', 'name': 'DEPENDENTJOB14', 'executor': '', 'owner': 'rob@fake.com', 'epsilon': 'PT15M', 'parents': ['DEPENDENTJOB4', 'DEPENDENTJOB8']}
Created 15 dependent job(s) on local Chronos
